### PR TITLE
fix: Avoid use documentScanner on regular camera

### DIFF
--- a/android/src/main/java/com/reactnativedocumentscanner/DocumentScannerModule.java
+++ b/android/src/main/java/com/reactnativedocumentscanner/DocumentScannerModule.java
@@ -37,7 +37,7 @@ public class DocumentScannerModule extends ReactContextBaseJavaModule {
                 final int resultCode,
                 final Intent intent) {
             // trigger callbacks (success, cancel, error)
-            if (requestCode == DOCUMENT_SCAN_REQUEST) {
+            if (documentScanner != null && requestCode == DOCUMENT_SCAN_REQUEST) {
                 documentScanner.handleDocumentScanIntentResult(
                         new ActivityResult(resultCode, intent)
                 );


### PR DESCRIPTION
Using regular camera on a application with react-native-document-scanner-plugin package installed causes the following runtime exception crahsing the app.


> Failure delivering result ResultInfo{who=null, request=1, result=-1, data=null} to activity {com.MainActivity}: java.lang.NullPointerException: Attempt to invoke virtual method 'void com.websitebeaver.documentscanner.DocumentScanner.handleDocumentScanIntentResult(androidx.activity.result.ActivityResult)' on a null object reference

This PR prevents use documentScanner when it's not available