### PR TITLE
fix(#29): incorrect typescript types inside npm package

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,5 @@
 
 {
   "extends": "./tsconfig",
-  "exclude": ["example"]
+  "exclude": ["example", "expo-plugin"]
 }


### PR DESCRIPTION
Closes #29

After adding `expo-plugin` directory inside root folder, the typescript types inside npm package were incorrectly generated.

The solution is to exclude any directory that includes typescript files apart from `src` (because it should be the only place for the source code that is exported by the library).

Before:

<img width="330" alt="Screen Shot 2022-11-21 at 15 17 18" src="https://user-images.githubusercontent.com/25980166/203077302-e6d78fc5-0a57-439d-af30-38fde1087781.png">

After:

<img width="348" alt="Screen Shot 2022-11-21 at 16 54 10" src="https://user-images.githubusercontent.com/25980166/203099664-814960a8-72e6-4880-b206-2840e3d78597.png">
