### PR TITLE
Fix IOS crash because of Memory leak

### DIFF
--- a/ios/DocumentScanner.swift
+++ b/ios/DocumentScanner.swift
@@ -7,7 +7,7 @@ class DocumentScanner: NSObject {
     }
     
     /** @property  documentScanner the document scanner */
-    let documentScanner = DocScanner()
+    private var documentScanner: DocScanner?
 
     @objc(scanDocument:withResolver:withRejecter:)
     func scanDocument(
@@ -16,8 +16,10 @@ class DocumentScanner: NSObject {
       reject: @escaping RCTPromiseRejectBlock
     ) -> Void {
         DispatchQueue.main.async {
+            self.documentScanner = DocScanner()
+
             // launch the document scanner
-            self.documentScanner.startScan(
+            self.documentScanner?.startScan(
                 RCTPresentedViewController(),
                 successHandler: { (scannedDocumentImages: [String]) in
                     // document scan success
@@ -25,16 +27,19 @@ class DocumentScanner: NSObject {
                         "status": "success",
                         "scannedImages": scannedDocumentImages
                     ])
+                    self.documentScanner = nil
                 },
                 errorHandler: { (errorMessage: String) in
                     // document scan error
                     reject("document scan error", errorMessage, nil)
+                    self.documentScanner = nil
                 },
                 cancelHandler: {
                     // when user cancels document scan
                     resolve([
                         "status": "cancel"
                     ])
+                    self.documentScanner = nil
                 },
                 responseType: options["responseType"] as? String,
                 croppedImageQuality: options["croppedImageQuality"] as? Int


### PR DESCRIPTION
There is a memory leak issue in the IOS module, and if users launch the plugin multiple times, the app crashes. I faced this issue during the app's QA testing.

Solution:
- Allocate the DocScanner object on each call and release it when the task completed/rejected
