### PR TITLE
chore: update ML Kit document scanner dependency to stable  16.0.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -74,5 +74,5 @@ def kotlin_version = getExtOrDefault("kotlinVersion")
 dependencies {
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.google.android.gms:play-services-mlkit-document-scanner:16.0.0-beta1"
+  implementation "com.google.android.gms:play-services-mlkit-document-scanner:16.0.0"
 }


### PR DESCRIPTION
This PR updates the ML Kit Document Scanner dependency from the beta release to the stable 16.0.0 version.